### PR TITLE
feat: add GitHub Personal Access Token support for increased rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ cd github-merge-analytics
 pip install -r requirements.txt
 ```
 
+## GitHub Authentication (Optional)
+
+To increase API rate limits from 60 to 5000 requests/hour, set up a GitHub Personal Access Token:
+
+1. Create a Personal Access Token:
+   - Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+   - Click "Generate new token (classic)"
+   - Select scopes: Only `public_repo` is needed for public repositories
+   - Copy the generated token
+
+2. Set the environment variable:
+```bash
+export GITHUB_TOKEN=ghp_your_token_here
+```
+
+3. Run the application as normal:
+```bash
+python main.py --repo https://github.com/owner/repo
+```
+
+The application will automatically detect and use the token for authentication.
+
 ## Usage
 
 ### Basic Usage
@@ -101,7 +123,9 @@ The generated graph includes:
 The application handles GitHub API rate limiting:
 - Uses appropriate User-Agent headers
 - Provides clear error messages if rate limits are exceeded
-- For higher rate limits, consider using GitHub authentication (not implemented in basic version)
+- **Supports GitHub Personal Access Token authentication for 5000 requests/hour** (vs 60 for unauthenticated)
+- Automatically detects and uses `GITHUB_TOKEN` environment variable
+- Falls back gracefully to unauthenticated requests if no token is provided
 
 ## Error Handling
 
@@ -129,8 +153,8 @@ The application includes comprehensive error handling for:
 
 ## Limitations
 
-- Only works with public repositories (authentication not implemented)
-- Subject to GitHub API rate limits (60 requests/hour for unauthenticated users)
+- Only works with public repositories
+- Subject to GitHub API rate limits (60 requests/hour without token, 5000 with token)
 - Requires graphical display for matplotlib output
 
 ## Contributing
@@ -150,8 +174,8 @@ This project is open source. Please check the repository for license details.
 ### Common Issues
 
 **"Rate limit exceeded"**:
-- Wait for the rate limit to reset (typically 60 minutes)
-- Consider implementing GitHub authentication for higher limits
+- Set up a GitHub Personal Access Token (see GitHub Authentication section above)
+- Or wait for the rate limit to reset (typically 60 minutes for unauthenticated requests)
 
 **"Invalid GitHub repository URL"**:
 - Ensure the URL is correctly formatted

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ A tool to analyze and visualize daily merge counts for GitHub repositories.
 """
 
 import argparse
+import os
 import re
 import sys
 from datetime import datetime, timedelta
@@ -25,6 +26,16 @@ class GitHubAnalytics:
         self.session.headers.update({
             'User-Agent': 'github-merge-analytics/1.0'
         })
+        
+        # Add GitHub token authentication if available
+        github_token = os.getenv('GITHUB_TOKEN')
+        if github_token:
+            self.session.headers.update({
+                'Authorization': f'Bearer {github_token}'
+            })
+            print("Using GitHub token authentication (5000 requests/hour limit)")
+        else:
+            print("No GitHub token found - using unauthenticated requests (60 requests/hour limit)")
     
     def parse_repo_url(self, url: str) -> Tuple[str, str]:
         """Parse GitHub repository URL to extract owner and repo name."""


### PR DESCRIPTION
Add GitHub Personal Access Token support to increase API rate limits from 60 to 5000 requests/hour.

## Changes
- Add GITHUB_TOKEN environment variable support in GitHubAnalytics.__init__()
- Include Bearer token in Authorization header when token is available
- Provide user feedback about authentication mode (5000 vs 60 requests/hour)
- Maintain fallback behavior for unauthenticated requests
- Update README.md with comprehensive token setup instructions
- Update documentation sections for rate limiting and troubleshooting

Fixes #4

Generated with [Claude Code](https://claude.ai/code)